### PR TITLE
Add default overlays for offers and storage, add trust

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,8 +35,31 @@ juju switch lma
 You can deploy the bundle with:
 
 ```shell
-juju deploy lma-light --channel=edge
+juju deploy lma-light --channel=edge --trust
 ```
 
 Currently the bundle is available only on the `edge` channel, using `edge` charms.
 When the charms graduate to `beta`, `candidate` and `stable`, we will issue the bundle in the same channels.
+
+The `--trust` option is needed by the charms in the `lma-light` bundle to be able to patch their K8s services to use the right ports (see this [Juju limitation](https://bugs.launchpad.net/juju/+bug/1936260)).
+
+We also make available some [**overlays**](https://juju.is/docs/sdk/bundle-reference) as convenience.
+A Juju overlay is a set of model-specific modifications, which reduce the amount of commands needed to set up a bundle like LMA Light.
+Specifically, we offer the following overlays:
+
+* the [`offers` overlay](./overlays/offers-overlay.yaml) exposes as offers the relation endpoints of the LMA Light charms that are likely to be consumed over [cross-model relations](https://juju.is/docs/olm/cross-model-relations).
+* the [`storage-small` overlays](./overlays/storage-small-overlay.yaml) provides a setup of the various storages for the LMA Light charms for a small setup.
+  Using an overlay for storage is fundamental for a productive setup, as you cannot change the amount of storage assigned to the various charms after the deployment of LMA Light.
+
+In order to use the overlays above, you need to:
+
+1. Download the overlays (or clone the repository)
+2. Pass the `--overlay <path-to-overlay-file-1> --overlay <path-to-overlay-file-2> ...` arguments to the `juju deploy` command
+
+For example, to deploy the LMA Light bundle with the offers overlay, you would do the following:
+
+```sh
+curl -L https://github.com/canonical/lma-light-bundle/blob/main/overlays/offer-overlay.yaml -O
+
+juju deploy lma-light --channel=edge --overlay ./offers-overlay.yaml
+```

--- a/bundle.yaml
+++ b/bundle.yaml
@@ -9,19 +9,22 @@ applications:
     charm: alertmanager-k8s
     channel: edge
     scale: 1
+    trust: true    
   prometheus:
     charm: prometheus-k8s
     channel: edge
     scale: 1
+    trust: true    
   grafana:
     charm: grafana-k8s
     channel: edge
     scale: 1
+    trust: true    
   loki:
     charm: loki-k8s
     channel: edge
     scale: 1
-
+    trust: true    
 relations:
 - - prometheus:alertmanager
   - alertmanager:alerting
@@ -29,26 +32,3 @@ relations:
   - prometheus:grafana-source
 - - grafana:grafana-source
   - loki:grafana-source
-
---- # overlay.yaml
-applications:
-  alertmanager:
-    offers:
-      alertmanager-karma-dashboard:
-        endpoints:
-          - karma-dashboard
-  grafana:
-    offers:
-      grafana-dashboards:
-        endpoints:
-          - grafana-dashboard
-  loki:
-    offers:
-      loki-logging:
-        endpoints:
-        - logging
-  prometheus:
-    offers:
-      prometheus-scrape:
-        endpoints:
-        - metrics-endpoint

--- a/overlays/offers-overlay.yaml
+++ b/overlays/offers-overlay.yaml
@@ -1,0 +1,21 @@
+applications:
+  alertmanager:
+    offers:
+      alertmanager-karma-dashboard:
+        endpoints:
+          - karma-dashboard
+  grafana:
+    offers:
+      grafana-dashboards:
+        endpoints:
+          - grafana-dashboard
+  loki:
+    offers:
+      loki-logging:
+        endpoints:
+        - logging
+  prometheus:
+    offers:
+      prometheus-scrape:
+        endpoints:
+        - metrics-endpoint

--- a/overlays/storage-small-overlay.yaml
+++ b/overlays/storage-small-overlay.yaml
@@ -1,0 +1,33 @@
+# Storage overlay
+#
+# This sample overlay shows how to configure the amount of
+# storage to grant to the various LMA components. It uses the
+# default `kubernetes` storage pool.
+---
+applications:
+  alertmanager:
+    storage:
+      # The Alertmanager operator uses the `database` storage to
+      # store nflog and silence snapshots.
+      # See the `--storage.path` argument of Alertmanager
+      data: kubernetes,2G,1
+  grafana:
+    storage:
+      # The Grafana operator uses the `database` storage to store
+      # configurations, plugins, user data, etc. That is, everything
+      # that is normally stored under /var/lib/grafana.
+      database: kubernetes,2G,1
+  loki:
+    storage:
+      # This is the volume used by loki for the index of boltdb-shipper.
+      # See https://grafana.com/docs/loki/latest/configuration/examples/
+      active-index-directory: kubernetes,2G,1
+      # Loki will store in this volume the chunks, which contain the
+      # actual log content.
+      # See https://grafana.com/docs/loki/latest/operations/storage/
+      loki-chunks: kubernetes,10G,1
+  prometheus:
+    storage:
+      # Prometheus operator uses the `database` storage to store TSDB data.
+      # See the `--storage.tsdb.path` argument of Prometheus.
+      database: kubernetes,10G,1


### PR DESCRIPTION
* Add default overlays for offers and a small storage setup
* Mark the charms as trusted (to actually be trusted it required the Juju admin to pass `--trust` to `juju deploy`)
* Additional documentation for how to deploy