### PR TITLE
increase timeout for integration test

### DIFF
--- a/tests/integration/helpers.py
+++ b/tests/integration/helpers.py
@@ -27,7 +27,7 @@ async def cli_deploy_bundle(ops_test, name: str, channel: str = "edge"):
     retcode, stdout, stderr = await ops_test.run(*run_args)
     assert retcode == 0, f"Deploy failed: {(stderr or stdout).strip()}"
     log.info(stdout)
-    await ops_test.model.wait_for_idle(timeout=120)
+    await ops_test.model.wait_for_idle(timeout=1000)
 
 
 async def get_unit_address(ops_test, app_name: str, unit_num: int) -> str:


### PR DESCRIPTION
This change was triggered by a [failed alertmanager integration](https://github.com/sed-i/alertmanager-operator/runs/3799447023?check_suite_focus=true) test.