### PR TITLE
use full url for overlays so they don't break on charmhub

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,8 +59,8 @@ We also make available some [**overlays**](https://juju.is/docs/sdk/bundle-refer
 A Juju overlay is a set of model-specific modifications, which reduce the amount of commands needed to set up a bundle like LMA Light.
 Specifically, we offer the following overlays:
 
-* the [`offers` overlay](https://github.com/canonical/lma-light-bundle/blob/main/overlays/offers-overlay.yaml) exposes as offers the relation endpoints of the LMA Light charms that are likely to be consumed over [cross-model relations](https://juju.is/docs/olm/cross-model-relations).
-* the [`storage-small` overlays](https://github.com/canonical/lma-light-bundle/blob/main/overlays/storage-small-overlay.yaml) provides a setup of the various storages for the LMA Light charms for a small setup.
+* the [`offers` overlay](https://raw.githubusercontent.com/canonical/lma-light-bundle/main/overlays/offers-overlay.yaml) exposes as offers the relation endpoints of the LMA Light charms that are likely to be consumed over [cross-model relations](https://juju.is/docs/olm/cross-model-relations).
+* the [`storage-small` overlays](https://raw.githubusercontent.com/canonical/lma-light-bundle/main/overlays/storage-small-overlay.yaml) provides a setup of the various storages for the LMA Light charms for a small setup.
   Using an overlay for storage is fundamental for a productive setup, as you cannot change the amount of storage assigned to the various charms after the deployment of LMA Light.
 
 In order to use the overlays above, you need to:

--- a/README.md
+++ b/README.md
@@ -59,8 +59,8 @@ We also make available some [**overlays**](https://juju.is/docs/sdk/bundle-refer
 A Juju overlay is a set of model-specific modifications, which reduce the amount of commands needed to set up a bundle like LMA Light.
 Specifically, we offer the following overlays:
 
-* the [`offers` overlay](./overlays/offers-overlay.yaml) exposes as offers the relation endpoints of the LMA Light charms that are likely to be consumed over [cross-model relations](https://juju.is/docs/olm/cross-model-relations).
-* the [`storage-small` overlays](./overlays/storage-small-overlay.yaml) provides a setup of the various storages for the LMA Light charms for a small setup.
+* the [`offers` overlay](https://github.com/canonical/lma-light-bundle/blob/main/overlays/offers-overlay.yaml) exposes as offers the relation endpoints of the LMA Light charms that are likely to be consumed over [cross-model relations](https://juju.is/docs/olm/cross-model-relations).
+* the [`storage-small` overlays](https://github.com/canonical/lma-light-bundle/blob/main/overlays/storage-small-overlay.yaml) provides a setup of the various storages for the LMA Light charms for a small setup.
   Using an overlay for storage is fundamental for a productive setup, as you cannot change the amount of storage assigned to the various charms after the deployment of LMA Light.
 
 In order to use the overlays above, you need to:

--- a/tox.ini
+++ b/tox.ini
@@ -69,7 +69,8 @@ commands =
 description = Run integration tests
 deps =
     jinja2
-    git+https://github.com/juju/python-libjuju.git
+    #git+https://github.com/juju/python-libjuju.git
+    juju
     pytest
     git+https://github.com/charmed-kubernetes/pytest-operator.git
 commands =


### PR DESCRIPTION
~~Linking to the gh page rather than the raw. Links to raw are in just below in the example.~~ Linking to raw.