### PR TITLE
Add test for removing cerftificate relations

### DIFF
--- a/render_bundle.py
+++ b/render_bundle.py
@@ -89,7 +89,7 @@ def render_bundle(template: Path, output: Path, variables: Optional[Dict[str, st
 
     # print(jinja_template.render(**variables))
     with open(output, "wt") as o:
-        jinja_template.stream(**variables).dump(o)
+        jinja_template.stream(**variables).dump(o)  # type: ignore
 
 
 if __name__ == "__main__":

--- a/tests/integration/helpers.py
+++ b/tests/integration/helpers.py
@@ -12,6 +12,7 @@ from typing import List, Optional, Union
 from juju.controller import Controller
 from juju.model import Model
 from pytest_operator.plugin import OpsTest
+import sh
 
 logger = logging.getLogger(__name__)
 
@@ -188,3 +189,10 @@ async def get_or_add_model(controller: Controller, model_name: str) -> Model:
         if model_name in await controller.get_models()
         else controller.add_model(model_name)
     )
+
+def get_related_apps(app_name: str, relation_name: str) -> List[str]:
+    return sh.jq(
+        '-r',
+        f'.applications.{app_name}.relations.{relation_name}[]."related-application"',
+        _in=sh.juju.status(app_name, "--relations", "--format=json", "--no-color")
+    ).splitlines()

--- a/tests/integration/helpers.py
+++ b/tests/integration/helpers.py
@@ -9,10 +9,10 @@ import urllib.request
 from pathlib import Path
 from typing import List, Optional, Union
 
+import sh
 from juju.controller import Controller
 from juju.model import Model
 from pytest_operator.plugin import OpsTest
-import sh
 
 logger = logging.getLogger(__name__)
 
@@ -190,9 +190,10 @@ async def get_or_add_model(controller: Controller, model_name: str) -> Model:
         else controller.add_model(model_name)
     )
 
+
 def get_related_apps(app_name: str, relation_name: str) -> List[str]:
     return sh.jq(
-        '-r',
+        "-r",
         f'.applications.{app_name}.relations.{relation_name}[]."related-application"',
-        _in=sh.juju.status(app_name, "--relations", "--format=json", "--no-color")
+        _in=sh.juju.status(app_name, "--relations", "--format=json", "--no-color"),
     ).splitlines()

--- a/tests/integration/test_bundle.py
+++ b/tests/integration/test_bundle.py
@@ -10,12 +10,13 @@ import ssl
 import tempfile
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Optional, Dict
+from typing import Dict, Optional
 from urllib.request import urlopen
-import sh
+
 import juju
 import juju.utils
 import pytest
+import sh
 from helpers import (
     ModelConfigChange,
     cli_deploy_bundle,
@@ -280,6 +281,7 @@ async def test_loki_receives_logs(ops_test: OpsTest):
     assert "flog-k8s" in as_str
     logger.info("loki is successfully receiving flog logs")
 
+
 @pytest.mark.abort_on_fail
 @pytest.mark.skipif(context.external_ca is None, reason="This test is only relevant for TLS")
 async def test_remove_certificate_relations(ops_test):
@@ -299,6 +301,7 @@ async def test_remove_certificate_relations(ops_test):
         logger.info("Attempting to reach %s (%s)...", name, url)
         response = urlopen(url, data=None, timeout=2.0)
         assert response.code == 200
+
 
 @pytest.mark.abort_on_fail
 async def test_remove(ops_test):

--- a/tox.ini
+++ b/tox.ini
@@ -77,6 +77,7 @@ deps =
     juju~=3.1.0  # must be compatible with the juju version installed by CI
     pytest
     pytest-operator
+    sh
 commands =
     pytest -vv --tb native --log-cli-level=INFO --color=yes -s {posargs} {[vars]tst_path}/integration
 


### PR DESCRIPTION
## Issue
https://github.com/canonical/grafana-k8s-operator/issues/328


## Solution
Add itest for removing certificate relations.


## Context
Ingress URL vs k8s fqdn vs loadbalancer IP -- which do we put in the cert?


## Testing Instructions
Run integration test.
Inspect traefik's cert with e.g.
```
echo | openssl s_client -showcerts -connect 10.43.8.188:443 | openssl x509 -text -noout
```
