### PR TITLE
Use microceph instead of hostpath storage

### DIFF
--- a/tests/manual/README.md
+++ b/tests/manual/README.md
@@ -30,11 +30,11 @@ end
 Launch the VM with:
 ```bash
 multipass launch 22.04 --cloud-init microk8s-ha.yaml \
-  --timeout 1800 \
-  --name three-node \
-  --memory 16G \
-  --cpus 14 \
-  --disk 100G
+ --timeout 2000 \
+ --name three-node \
+ --memory 32G \
+ --cpus 16 \
+ --disk 160G
 ```
 
 Then shell into the vm, get the `three-nodes-overlay.yaml` file and run:

--- a/tests/manual/microk8s-ha.yaml
+++ b/tests/manual/microk8s-ha.yaml
@@ -8,7 +8,7 @@
 #  --name three-node \
 #  --memory 32G \
 #  --cpus 16 \
-#  --disk 100G
+#  --disk 160G
 #
 # This cloud-config creates a 3-node microk8s ha cluster for juju (e.g. in a nested multipass VM).
 # A microk8s controller and an empty model are created as part of the cloud-init script,
@@ -33,6 +33,7 @@ snap:
 
 write_files:
 - path: "/run/microk8s-cloud-init.yaml"
+  # This is the cloud-config for the microk8s nodes that will we nested inside the outer VM.
   permissions: "0666"
   content: |
     #cloud-config
@@ -41,6 +42,8 @@ write_files:
     packages:
     - jq
     - kitty-terminfo
+    # Need this package to have the kernel rbd module, which is needed by ceph.
+    - linux-image-extra-virtual
 
     snap:
       commands:
@@ -67,7 +70,7 @@ write_files:
       echo "net.ipv6.conf.lo.disable_ipv6=1" | tee -a /etc/sysctl.conf
       sysctl -p
 
-      # disable unnecessary services
+      echo "Disabling unnecessary systemd services"
       systemctl disable man-db.timer man-db.service --now
       systemctl disable apport.service apport-autoreport.service  --now
       systemctl disable apt-daily.service apt-daily.timer --now
@@ -103,10 +106,13 @@ write_files:
       set -eux
 
       # Setup microceph
+      modprobe rbd
       microceph cluster bootstrap
-      microceph.ceph config set global osd_pool_default_size 1
+      # Set the replication to 2x and make the failure domain OSD instead of HOST, so that we only
+      # need 2 min OSDs, not 2 hosts, to spread data across.
+      microceph.ceph config set global osd_pool_default_size 2
       microceph.ceph config set osd osd_crush_chooseleaf_type 0
-      microceph disk add loop,20G,1
+      microceph disk add loop,20G,2
       microk8s connect-external-ceph
       microceph.ceph status
 
@@ -122,7 +128,7 @@ runcmd:
   swapoff -a
 
 - |
-  # disable unnecessary services
+  echo "Disabling unnecessary systemd services"
   systemctl disable man-db.timer man-db.service --now
   systemctl disable apport.service apport-autoreport.service  --now
   systemctl disable apt-daily.service apt-daily.timer --now
@@ -143,21 +149,26 @@ runcmd:
   # Set up cluster
   # Strictly confined snap cannot see `/run`.
   cp /run/microk8s-cloud-init.yaml ~ubuntu/
-  sudo -u ubuntu multipass launch 22.04 --name node-0 --memory 8G --cpus 4 --disk 30G --cloud-init ~ubuntu/microk8s-cloud-init.yaml
+
+  echo "Launching node-0..."
+  sudo -u ubuntu multipass launch 22.04 --timeout 2000 --name node-0 --memory 8G --cpus 4 --disk 50G --cloud-init ~ubuntu/microk8s-cloud-init.yaml
   sudo -u ubuntu multipass exec node-0 -- cloud-init status --wait
   sudo -u ubuntu multipass exec node-0 -- microk8s config > ~ubuntu/node-0.kube.conf
   chown ubuntu:ubuntu ~ubuntu/node-0.kube.conf
 
-  sudo -u ubuntu multipass launch 22.04 --name node-1 --memory 8G --cpus 4 --disk 30G --cloud-init ~ubuntu/microk8s-cloud-init.yaml
+  echo "Launching node-1..."
+  sudo -u ubuntu multipass launch 22.04 --timeout 2000 --name node-1 --memory 8G --cpus 4 --disk 50G --cloud-init ~ubuntu/microk8s-cloud-init.yaml
   sudo -u ubuntu multipass exec node-1 -- cloud-init status --wait
   sudo -u ubuntu multipass exec node-1 -- microk8s config > ~ubuntu/node-1.kube.conf
   chown ubuntu:ubuntu ~ubuntu/node-1.kube.conf
 
-  sudo -u ubuntu multipass launch 22.04 --name node-2 --memory 8G --cpus 4 --disk 30G --cloud-init ~ubuntu/microk8s-cloud-init.yaml
+  echo "Launching node-2..."
+  sudo -u ubuntu multipass launch 22.04 --timeout 2000 --name node-2 --memory 8G --cpus 4 --disk 50G --cloud-init ~ubuntu/microk8s-cloud-init.yaml
   sudo -u ubuntu multipass exec node-2 -- cloud-init status --wait
   sudo -u ubuntu multipass exec node-2 -- microk8s config > ~ubuntu/node-2.kube.conf
   chown ubuntu:ubuntu ~ubuntu/node-2.kube.conf
 
+  echo "Joining microk8s nodes..."
   # https://unix.stackexchange.com/questions/230673/how-to-generate-a-random-string
   TOKEN=$(tr -dc a-f0-9 </dev/urandom | head -c 32)
   URL=$(sudo -u ubuntu multipass exec node-0 -- sudo microk8s add-node --token $TOKEN --format json | jq -r '.urls[0]')
@@ -169,9 +180,11 @@ runcmd:
 
   # Make sure everything is ok
   sudo -u ubuntu multipass exec node-0 microk8s kubectl get node
+  sudo -u ubuntu multipass exec node-1 microk8s kubectl get node
+  sudo -u ubuntu multipass exec node-2 microk8s kubectl get node
 
 - |
-  # Setup juju
+  echo "Setting up juju..."
   sudo -u ubuntu mkdir -p /home/ubuntu/.local/share/juju
 
   # Gotta sleep a bit before add-k8s, otherwise:

--- a/tests/manual/microk8s-ha.yaml
+++ b/tests/manual/microk8s-ha.yaml
@@ -4,10 +4,10 @@
 # host (or outer vm) we'd need 14cpu16gb.
 #
 # multipass launch 22.04 --cloud-init microk8s-ha.yaml \
-#  --timeout 1800 \
+#  --timeout 2000 \
 #  --name three-node \
-#  --memory 16G \
-#  --cpus 14 \
+#  --memory 32G \
+#  --cpus 16 \
 #  --disk 100G
 #
 # This cloud-config creates a 3-node microk8s ha cluster for juju (e.g. in a nested multipass VM).
@@ -47,6 +47,11 @@ write_files:
       - snap install microk8s --channel=1.29-strict/stable
       - snap alias microk8s.kubectl kubectl
       - snap alias microk8s.kubectl k
+
+      # https://charmhub.io/cos-lite/docs/tutorials/distributed-storage?channel=latest/edge
+      - snap install microceph
+      - snap refresh --hold microceph
+
       - snap refresh
 
     runcmd:
@@ -84,8 +89,8 @@ write_files:
       microk8s.kubectl rollout status deployments/coredns -n kube-system -w --timeout=600s
 
       microk8s.enable rbac
-      microk8s.enable hostpath-storage
-      microk8s.kubectl rollout status deployments/hostpath-provisioner -n kube-system -w --timeout=600s
+      microk8s.enable rook-ceph
+      microk8s.kubectl rollout status deployment.apps/rook-ceph-operator -n rook-ceph -w --timeout=600s
 
       # MetalLB
       IPADDR=$(ip -4 -j route get 2.2.2.2 | jq -r '.[] | .prefsrc')
@@ -93,6 +98,17 @@ write_files:
       microk8s.kubectl rollout status daemonset.apps/speaker -n metallb-system -w --timeout=600s
 
       usermod -a -G snap_microk8s ubuntu
+
+    - |
+      set -eux
+
+      # Setup microceph
+      microceph cluster bootstrap
+      microceph.ceph config set global osd_pool_default_size 1
+      microceph.ceph config set osd osd_crush_chooseleaf_type 0
+      microceph disk add loop,20G,1
+      microk8s connect-external-ceph
+      microceph.ceph status
 
 runcmd:
 - DEBIAN_FRONTEND=noninteractive apt-get remove -y landscape-client landscape-common adwaita-icon-theme humanity-icon-theme
@@ -127,17 +143,17 @@ runcmd:
   # Set up cluster
   # Strictly confined snap cannot see `/run`.
   cp /run/microk8s-cloud-init.yaml ~ubuntu/
-  sudo -u ubuntu multipass launch 22.04 --name node-0 --memory 4G --cpus 2 --disk 30G --cloud-init ~ubuntu/microk8s-cloud-init.yaml
+  sudo -u ubuntu multipass launch 22.04 --name node-0 --memory 8G --cpus 4 --disk 30G --cloud-init ~ubuntu/microk8s-cloud-init.yaml
   sudo -u ubuntu multipass exec node-0 -- cloud-init status --wait
   sudo -u ubuntu multipass exec node-0 -- microk8s config > ~ubuntu/node-0.kube.conf
   chown ubuntu:ubuntu ~ubuntu/node-0.kube.conf
 
-  sudo -u ubuntu multipass launch 22.04 --name node-1 --memory 4G --cpus 2 --disk 30G --cloud-init ~ubuntu/microk8s-cloud-init.yaml
+  sudo -u ubuntu multipass launch 22.04 --name node-1 --memory 8G --cpus 4 --disk 30G --cloud-init ~ubuntu/microk8s-cloud-init.yaml
   sudo -u ubuntu multipass exec node-1 -- cloud-init status --wait
   sudo -u ubuntu multipass exec node-1 -- microk8s config > ~ubuntu/node-1.kube.conf
   chown ubuntu:ubuntu ~ubuntu/node-1.kube.conf
 
-  sudo -u ubuntu multipass launch 22.04 --name node-2 --memory 4G --cpus 2 --disk 30G --cloud-init ~ubuntu/microk8s-cloud-init.yaml
+  sudo -u ubuntu multipass launch 22.04 --name node-2 --memory 8G --cpus 4 --disk 30G --cloud-init ~ubuntu/microk8s-cloud-init.yaml
   sudo -u ubuntu multipass exec node-2 -- cloud-init status --wait
   sudo -u ubuntu multipass exec node-2 -- microk8s config > ~ubuntu/node-2.kube.conf
   chown ubuntu:ubuntu ~ubuntu/node-2.kube.conf
@@ -161,7 +177,7 @@ runcmd:
   # Gotta sleep a bit before add-k8s, otherwise:
   # ERROR making juju admin credentials in cluster: ensuring cluster role "juju-credential-fabcd43f" in namespace "kube-system": Get "https://10.25.94.86:16443/apis/rbac.authorization.k8s.io/v1/clusterroles/juju-credential-fabcd43f": net/http: TLS handshake timeout
   sleep 30
-  sudo -u ubuntu sh -c 'KUBECONFIG="/home/ubuntu/node-0.kube.conf" juju add-k8s microk8s-cluster --client'
+  sudo -u ubuntu sh -c 'KUBECONFIG="/home/ubuntu/node-0.kube.conf" juju add-k8s microk8s-cluster --storage=ceph-rbd --client'
   sudo -u ubuntu juju bootstrap microk8s-cluster k8s
   sudo -u ubuntu juju add-model welcome-k8s
 


### PR DESCRIPTION
## Issue
Currently (after #111), the microk8s ha cloud init script uses hostpath storage, which is not [what we recommend](https://charmhub.io/topics/canonical-observability-stack/reference/best-practices).


## Solution
Update the reference deployment to use distributed storage.


## Context
- https://bugs.launchpad.net/juju/+bug/2069659


## Testing Instructions
<!-- What steps need to be taken to test this PR? -->


## Upgrade Notes
<!-- To upgrade from an older revision of charmed prometheus, ... -->
