### PR TITLE
Update track from latest to 1

### DIFF
--- a/bundle.yaml.j2
+++ b/bundle.yaml.j2
@@ -16,7 +16,7 @@ applications:
     resources:
         traefik-image: "docker.io/ubuntu/traefik:2-22.04"
     {%- else %}
-    channel: {{ channel|default('edge', true) }}
+    channel: {{ channel|default('1/edge', true) }}
     {%- endif %}
   alertmanager:
     charm: {{ alertmanager|default('alertmanager-k8s', true) }}
@@ -26,7 +26,7 @@ applications:
     resources:
         alertmanager-image: "docker.io/ubuntu/alertmanager:0-22.04"
     {%- else %}
-    channel: {{ channel|default('edge', true) }}
+    channel: {{ channel|default('1/edge', true) }}
     {%- endif %}
   prometheus:
     charm: {{ prometheus|default('prometheus-k8s', true) }}
@@ -36,7 +36,7 @@ applications:
     resources:
       prometheus-image: "docker.io/ubuntu/prometheus:2-22.04"
     {%- else %}
-    channel: {{ channel|default('edge', true) }}
+    channel: {{ channel|default('1/edge', true) }}
     {%- endif %}
   grafana:
     charm: {{ grafana|default('grafana-k8s', true) }}
@@ -47,7 +47,7 @@ applications:
       grafana-image: "docker.io/ubuntu/grafana:9-22.04"
       litestream-image: "docker.io/litestream/litestream:0.4.0-beta.2"
     {%- else %}
-    channel: {{ channel|default('edge', true) }}
+    channel: {{ channel|default('1/edge', true) }}
     {%- endif %}
   catalogue:
     charm: {{ catalogue|default('catalogue-k8s', true) }}
@@ -57,7 +57,7 @@ applications:
     resources:
       catalogue-image: "ghcr.io/canonical/catalogue-k8s-operator:dev"
     {%- else %}
-    channel: {{ channel|default('edge', true) }}
+    channel: {{ channel|default('1/edge', true) }}
     {%- endif %}
     options:
       title: Canonical Observability Stack
@@ -73,7 +73,7 @@ applications:
     resources:
       loki-image: "docker.io/ubuntu/loki:2-22.04"
     {%- else %}
-    channel: {{ channel|default('edge', true) }}
+    channel: {{ channel|default('1/edge', true) }}
     {%- endif %}
 
 relations:

--- a/bundle.yaml.j2
+++ b/bundle.yaml.j2
@@ -16,7 +16,7 @@ applications:
     resources:
         traefik-image: "docker.io/ubuntu/traefik:2-22.04"
     {%- else %}
-    channel: {{ channel|default('1/edge', true) }}
+    channel: latest/stable
     {%- endif %}
   alertmanager:
     charm: {{ alertmanager|default('alertmanager-k8s', true) }}

--- a/overlays/testing-overlay.yaml
+++ b/overlays/testing-overlay.yaml
@@ -22,7 +22,7 @@ applications:
       memory: 1Mi
   avalanche:
     charm: avalanche-k8s
-    channel: edge
+    channel: 1/edge
     scale: 2
     trust: true
     options:

--- a/render_bundle.py
+++ b/render_bundle.py
@@ -18,7 +18,7 @@ BUNDLE_TEMPLATE_PATH = os.path.join(this_script_dir, "bundle.yaml.j2")
 
 
 def read_bundle_template(
-    filename: Union[str, Path] = BUNDLE_TEMPLATE_PATH
+    filename: Union[str, Path] = BUNDLE_TEMPLATE_PATH,
 ) -> Tuple[str, Set[str]]:
     """Read the template file from disk.
 

--- a/tox.ini
+++ b/tox.ini
@@ -105,10 +105,10 @@ deps =
 allowlist_externals =
     /usr/bin/env
 commands =
-    edge: /usr/bin/env python3 {toxinidir}/render_bundle.py {toxinidir}/bundle.yaml --channel=edge
-    beta: /usr/bin/env python3 {toxinidir}/render_bundle.py {toxinidir}/bundle.yaml --channel=beta
-    candidate: /usr/bin/env python3 {toxinidir}/render_bundle.py {toxinidir}/bundle.yaml --channel=candidate
-    stable: /usr/bin/env python3 {toxinidir}/render_bundle.py {toxinidir}/bundle.yaml --channel=stable
+    edge: /usr/bin/env python3 {toxinidir}/render_bundle.py {toxinidir}/bundle.yaml --channel=1/edge
+    beta: /usr/bin/env python3 {toxinidir}/render_bundle.py {toxinidir}/bundle.yaml --channel=1/beta
+    candidate: /usr/bin/env python3 {toxinidir}/render_bundle.py {toxinidir}/bundle.yaml --channel=1/candidate
+    stable: /usr/bin/env python3 {toxinidir}/render_bundle.py {toxinidir}/bundle.yaml --channel=1/stable
 
 [testenv:datasheet]
 description = Plot load test results

--- a/tox.ini
+++ b/tox.ini
@@ -77,6 +77,7 @@ deps =
     juju
     pytest
     pytest-operator
+    sh
 commands =
     pytest -vv --tb native --log-cli-level=INFO --color=yes -s {posargs} {[vars]tst_path}/integration
 


### PR DESCRIPTION
## Issue
Bundle yaml was pointing to the closed "latest" track.


## Solution
Update to "1".


## Context
Had to upload with charmcraft 2.x: https://github.com/canonical/charmcraft/issues/2341.

Now we have the bundle "latest" track pointing to the "1" track, but I didn't want to reshuffle too much to avoid breaking even more users. We are not going to have cos-lite bundle yaml for track 2 anyway.